### PR TITLE
Updated container base image to use node 4.4.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,6 @@
 
 FROM node:4.4.5
 
-#tenstartups/alpine:latest
-
 MAINTAINER Marc Lennox <marc.lennox@gmail.com>
 
 # Install node packages.

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,11 @@
 # http://github.com/tenstartups/redis-commander-docker
 #
 
-FROM tenstartups/alpine:latest
+FROM node:4.4.5
+
+#tenstartups/alpine:latest
 
 MAINTAINER Marc Lennox <marc.lennox@gmail.com>
-
-# Install packages.
-RUN \
-  apk --update add nodejs && \
-  rm -rf /var/cache/apk/*
 
 # Install node packages.
 RUN npm install -g redis-commander


### PR DESCRIPTION
I noticed that this container was broken, it suffered from the issue below.  I've updated it to use node 4.4.4, thought you might be interested.  Cheers!

https://github.com/joeferner/redis-commander/issues/168