### PR TITLE
Update README and LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@ Apache License
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2016 Marc Lennox <marc.lennox@gmail.com>
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ redisCommander:
   ports:
     - "8081:8081"
 ```
-Followed by: `fig up`
+Followed by: `docker-compose up`


### PR DESCRIPTION
The README still used `fig`. Updated to `docker-compose`.

Also, the LICENSE was copy-pasted without filling the copyright owner/date.